### PR TITLE
update `beLike` to work recursively for arrays and objects

### DIFF
--- a/built-in.js
+++ b/built-in.js
@@ -147,6 +147,62 @@ var testInstanceOf = function () {
     return expression;
 };
 
+var isPOJO = function (item) {
+    return Object.prototype.toString.call(item) === '[object Object]';
+};
+
+/**
+* return `true` if `item` is an Object (POJO) or Array
+*/
+var isIterable = function (item) {
+    return Array.isArray(item) || isPOJO(item);
+};
+
+/**
+* Test equality.
+* @return {Boolean}
+*/
+var areEqual = function (a, b) {
+    var expression;
+
+    if (isIterable(a)) {
+        expression = objectsMatch(a, b);
+    } else {
+        expression = a == b;
+    }
+
+    return expression;
+};
+
+/**
+* Compares two objects.  Returns true if both have the same
+* properties with the same equality.
+*/
+var objectsMatch = function (a, b) {
+    var isMatch = false;
+    var aKeys = Object.keys(a);
+    var bKeys = Object.keys(b);
+    
+    if (isIterable(a) && isIterable(b)) {
+        if (aKeys.length === bKeys.length) {
+            isMatch = true;
+
+            aKeys.forEach(function (key) {
+                if (isMatch) {
+                    if (isIterable(a[key]) ||
+                        isIterable(b[key])) {
+                            isMatch = areEqual(a[key], b[key]);
+                    } else {
+                        isMatch = a[key] == b[key];
+                    }
+                }
+            }, this);
+        }
+    }
+
+    return isMatch;
+};
+
 /**
 * Throws error based on identity comparison.
 * @param {*} criterion
@@ -216,7 +272,8 @@ exports.beLessThan = {
 */
 exports.beLike = {
     fn: function () {
-        return this.actual == this.expected;
+        // TODO: Add dcumentation for how this works with objects/arrays.
+        return areEqual(this.actual, this.expected);
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,100 @@ describe('beLike', function () {
             will('').beLike(true);
         });
     });
+
+    describe('when testing objects', function () {
+        it('should throw when arrays do not match', function () {
+            assert.throws(function () {
+                will([1, 2, 3]).beLike([1, 2]);
+            });
+        });
+
+        it('should throw when arrays match, but in wrong order', function () {
+            assert.throws(function () {
+                will([1, 2, 3]).beLike([3, 1, 2]);
+            });
+        });
+
+        it('should throw when objects\' properties do not match', function () {
+            assert.throws(function () {
+                will({
+                    foo: 'bar',
+                    baz: 123,
+                    quux: null
+                }).beLike({});
+            });
+        });
+
+        it('should throw when objects\' values do not match (==)', function () {
+            assert.throws(function () {
+                will({
+                    foo: 'bar',
+                    baz: 123,
+                    quux: null
+                }).beLike({
+                    foo: 'bingo',
+                    baz: 'bango',
+                    quux: 'bongo'
+                });
+            });
+        });
+
+        it('should not throw when objects\' values match (==)', function () {
+            assert.doesNotThrow(function () {
+                will({
+                    foo: 'bar',
+                    baz: 123,
+                    quux: null
+                }).beLike({
+                    foo: 'bar',
+                    baz: 123,
+                    quux: null
+                });
+            });
+        });
+
+        it('should work when arrays are found', function () {
+            assert.doesNotThrow(function () {
+                will({
+                    foo: [1, 2, 3]
+                }).beLike({
+                    foo: [1, 2, 3]  
+                });
+            });
+        });
+
+        it('should throw when non-matching arrays are found', function () {
+            assert.throws(function () {
+                will({
+                    foo: [1, 2, 3]
+                }).beLike({
+                    foo: [1, 2]
+                });
+            });
+        });
+
+        it('should work recursively', function () {
+            assert.throws(function () {
+                will({
+                    foo: {
+                        bar: {
+                            baz: {
+                                quux: true
+                            }
+                        }
+                    }
+                }).beLike({
+                    foo: {
+                        bar: {
+                            baz: {
+                                quux: false
+                            }
+                        }
+                    }
+                });
+            });
+        });
+    });
 });
 
 describe('beA/beAn', function () {


### PR DESCRIPTION
fix enhancement #6 
